### PR TITLE
Bugfix: Swapped parameters in implode() function

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -108,7 +108,7 @@ class Pusher implements PusherInterface
 			throw new PusherException("header type is not valid");
 		}
 
-		return implode($line, ', ');
+		return implode(', ', $line);
 	}
 
 	/**


### PR DESCRIPTION
According to: https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters

And please create a new version v1.1 of this project for composer.

Thanks!