### PR TITLE
Bugfix: removed __construct(), __clone(), __wakeup()

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -170,7 +170,4 @@ class Pusher implements PusherInterface
 		return implode('; ', $opts);
 	}
 
-	protected function __construct() { }
-	protected function __clone() { }
-	protected function __wakeup() { }
 }


### PR DESCRIPTION
In PHP 8.0.0RC3 version, the following exception is thrown:

Warning: The magic method Melbahja\Http2\Pusher::__wakeup() must have public visibility in /.../vendor/melbahja/http2-pusher/src/Pusher.php on line 175 

The solution is to remove the empty methods __construct(), __clone(), __wakeup().

Thanks.